### PR TITLE
Add dummy implementations to satisfy new IOBluetoothDeviceInquiryDelegate protocol in 10.8

### DIFF
--- a/src/mac/_lightblue.py
+++ b/src/mac/_lightblue.py
@@ -470,8 +470,19 @@ class _AsyncDeviceInquiry(Foundation.NSObject):
     def deviceInquiryStarted_(self, inquiry):
         if self.cb_started:
             self.cb_started()
-        
-        
+
+    # - (void)deviceInquiryDeviceNameUpdated:device:devicesRemaining:
+    def deviceInquiryDeviceNameUpdated_device_devicesRemaining_(self, sender,
+                                                              device,
+                                                              devicesRemaining):
+        pass
+
+    # - (void)deviceInquiryUpdatingDeviceNamesStarted:devicesRemaining:
+    def deviceInquiryUpdatingDeviceNamesStarted_devicesRemaining_(self, sender,
+                                                                devicesRemaining):
+        pass
+
+
 ### utility methods ###
 
     


### PR DESCRIPTION
The author of #2 and I have both found that the latest versions of Mac OS X (10.8.2 here, and 10.8.3 for him) have new required methods in the [IOBluetoothDeviceInquiryDelegate protocol](http://developer.apple.com/library/mac/#documentation/IOBluetooth/Reference/IOBluetoothDeviceInquiryDelegate_reference/translated_content/IOBluetoothDeviceInquiryDelegate.html#//apple_ref/doc/uid/TP40011426). I've added some no-op methods in order to satisfy the protocol and to allow LightBlue to continue.

Thanks for posting this updated version! It's been a big help.
